### PR TITLE
Release 1.0.2 & added publish workflow with provenance

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,46 @@
+name: Release
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  release:
+    name: Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+    steps:
+      - uses: actions/checkout@v4
+      - uses: pnpm/action-setup@v2
+      - uses: actions/setup-node@v4
+        with:
+          cache: 'pnpm'
+          node-version: '20'
+          registry-url: https://registry.npmjs.org
+
+      # Get the 'version' field out of the package.json file
+      - name: Get package.json version
+        id: package-json-version
+        run: echo "version=$(cat package.json | jq '.version' --raw-output)" >> $GITHUB_OUTPUT
+      # Abort if the version in the package.json file (prefixed with 'v') doesn't match the tag name of the release
+      - name: Check package.json version against tag name
+        if: format('v{0}', steps.package-json-version.outputs.version) != github.event.release.tag_name
+        uses: actions/github-script@v3
+        with:
+          script: core.setFailed('Release tag does not match package.json version!')
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: Build the package
+        run: pnpm build
+
+      - name: Create Publish to npm
+        run: pnpm publish --provenance
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to **dot-diver** will be documented here. Inspired by [keep 
 
 ## Unreleased
 
+## [1.0.2](https://github.com/clickbar/dot-diver/tree/1.0.2) (2023-11-02)
+
 - Updated dependencies
 - Formatted code with new lint rules
 - Fixed testcase for new TypeScript behavior

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to **dot-diver** will be documented here. Inspired by [keep 
 - Formatted code with new lint rules
 - Fixed testcase for new TypeScript behavior
 - Added guards against prototype pollution, thanks to @d3ng03 (<https://github.com/clickbar/dot-diver/security/advisories/GHSA-9w5f-mw3p-pj47>)
+- Added provenance for the published package (See https://docs.npmjs.com/generating-provenance-statements)
 
 ## [1.0.1](https://github.com/clickbar/dot-diver/tree/1.0.1) (2023-03-26)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clickbar/dot-diver",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Types and utilities to access object properties by dot notation.",
   "packageManager": "pnpm@8.8.0",
   "types": "dist/index.d.ts",


### PR DESCRIPTION
This PR bumps the version to 1.0.2 and also adds a release workflow to publish the package with provenance.