### PR TITLE
Enable rollup for types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to **dot-diver** will be documented here. Inspired by [keep 
 
 ## Unreleased
 
-- Fix <https://github.com/clickbar/dot-diver/issues/15> by enabling rollup for types
+- Enable rollup of typescript declaration files
 
 ## [1.0.3](https://github.com/clickbar/dot-diver/tree/1.0.3) (2023-11-03)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to **dot-diver** will be documented here. Inspired by [keep 
 
 ## Unreleased
 
+- Fix <https://github.com/clickbar/dot-diver/issues/15> by enabling rollup for types
+
 ## [1.0.3](https://github.com/clickbar/dot-diver/tree/1.0.3) (2023-11-03)
 
 - Rerelease with fixed release pipeline 😅
@@ -14,7 +16,7 @@ All notable changes to **dot-diver** will be documented here. Inspired by [keep 
 - Formatted code with new lint rules
 - Fixed testcase for new TypeScript behavior
 - Added guards against prototype pollution, thanks to @d3ng03 (<https://github.com/clickbar/dot-diver/security/advisories/GHSA-9w5f-mw3p-pj47>)
-- Added provenance for the published package (See https://docs.npmjs.com/generating-provenance-statements)
+- Added provenance for the published package (See <https://docs.npmjs.com/generating-provenance-statements>)
 
 ## [1.0.1](https://github.com/clickbar/dot-diver/tree/1.0.1) (2023-03-26)
 

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,5 +11,5 @@ export default defineConfig({
       fileName: 'index',
     },
   },
-  plugins: [dts()],
+  plugins: [dts({ rollupTypes: true })],
 })


### PR DESCRIPTION
This should fix https://github.com/clickbar/dot-diver/issues/15.

By enabling rollup for typescript types we ensure that the build declaration file is at dist/index.d.ts.

Otherwise the declaration files would be kept in the same structure as our source which could be problematic if the src structure changed, leading to a change in the resulting structure of our built files (in dist/) which could be different to the path definitions in our package.json.

I'm still unsure why the built behavior changed.

Could you also test this change @saibotk