### PR TITLE
fix: Type generation paths & package.json exports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to **dot-diver** will be documented here. Inspired by [keep 
 
 ## Unreleased
 
+- Fixed wrong type transformation via vite-dts-plugin (see #15)
+
 ## [1.0.3](https://github.com/clickbar/dot-diver/tree/1.0.3) (2023-11-03)
 
 - Rerelease with fixed release pipeline 😅

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ All notable changes to **dot-diver** will be documented here. Inspired by [keep 
 ## Unreleased
 
 - Fixed wrong type transformation via vite-dts-plugin (see #15)
+- Fixed wrong cjs export filename
+- Fixed order of types export to be the first export
 
 ## [1.0.3](https://github.com/clickbar/dot-diver/tree/1.0.3) (2023-11-03)
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "exports": {
     ".": {
       "import": "./dist/index.js",
-      "require": "./dist/index.cjs",
+      "require": "./dist/index.umd.cjs",
       "types": "./dist/index.d.ts"
     }
   },

--- a/package.json
+++ b/package.json
@@ -6,9 +6,9 @@
   "types": "dist/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/index.d.ts",
       "import": "./dist/index.js",
-      "require": "./dist/index.umd.cjs",
-      "types": "./dist/index.d.ts"
+      "require": "./dist/index.umd.cjs"
     }
   },
   "files": [

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -11,5 +11,9 @@ export default defineConfig({
       fileName: 'index',
     },
   },
-  plugins: [dts()],
+  plugins: [
+    dts({
+      include: ['src/'],
+    }),
+  ],
 })


### PR DESCRIPTION
This fix overrides the include parameter, which defaults to the tsconfig's include setting.

Now only files in the src/ directory are considered for type generation.

Fixes #15

See https://github.com/qmhc/vite-plugin-dts

Additionally this PR fixes 2 other issues:
- 1. The export for the common js file was also wrong and was missing a `umd.`.
- 2. The export order for the types definitions is recommended to be the first one. See https://publint.dev/rules#exports_types_should_be_first