### PR TITLE
ci: Fix changelog enforcer skip label

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -8,7 +8,7 @@ jobs:
   changelog:
     runs-on: ubuntu-latest
     steps:
-      - uses: dangoslen/changelog-enforcer@v3.3.2
+      - uses: dangoslen/changelog-enforcer@v3.5.1
         with:
           changeLogPath: 'CHANGELOG.md'
-          skipLabel: 'skip-changelog'
+          skipLabels: 'skip-changelog'


### PR DESCRIPTION
The option was renamed.
Additionally the action was updated to the most recent version.