### PR TITLE
chore(ci): fix running ci on PRs & reduce permissions

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -3,6 +3,9 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
 
+permissions:
+  contents: read
+
 jobs:
   # Enforces the update of a changelog file on every pull request
   changelog:

--- a/.github/workflows/linting-and-formatting.yml
+++ b/.github/workflows/linting-and-formatting.yml
@@ -1,6 +1,13 @@
 name: Linting and formatting
 
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
 
 # Cancels all previous workflow runs for the same branch that have not yet completed.
 concurrency:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,13 @@
 name: Tests
 
-on: [push]
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
 
 # Cancels all previous workflow runs for the same branch that have not yet completed.
 concurrency:


### PR DESCRIPTION
This commit reduces the permissions to contents read everywhere and also correctly runs the CI for external pull requests.