### PR TITLE
fix(get): reactivity on proxy objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ All notable changes to **dot-diver** will be documented here. Inspired by [keep 
 
 ## Unreleased
 
+- Fixed `getByPath` not triggering reactivity on Proxy objects (fixes #34, thanks @Tofandel)
+
 ## [1.0.6](https://github.com/clickbar/dot-diver/tree/1.0.6) (2024-03-25)
 
 - Fixed breaking change introduced in the type of SearchableObject

--- a/package.json
+++ b/package.json
@@ -47,6 +47,7 @@
   "devDependencies": {
     "@clickbar/eslint-config-typescript": "^10.2.0",
     "@types/node": "^20.12.12",
+    "@vue/reactivity": "^3.4.38",
     "eslint": "^8.57.0",
     "prettier": "^3.2.5",
     "typescript": "^5.4.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ devDependencies:
   '@types/node':
     specifier: ^20.12.12
     version: 20.12.12
+  '@vue/reactivity':
+    specifier: ^3.4.38
+    version: 3.4.38
   eslint:
     specifier: ^8.57.0
     version: 8.57.0
@@ -930,8 +933,18 @@ packages:
       vue-template-compiler: 2.7.16
     dev: true
 
+  /@vue/reactivity@3.4.38:
+    resolution: {integrity: sha512-4vl4wMMVniLsSYYeldAKzbk72+D3hUnkw9z8lDeJacTxAkXeDAP1uE9xr2+aKIN0ipOL8EG2GPouVTH6yF7Gnw==}
+    dependencies:
+      '@vue/shared': 3.4.38
+    dev: true
+
   /@vue/shared@3.4.27:
     resolution: {integrity: sha512-DL3NmY2OFlqmYYrzp39yi3LDkKxa5vZVwxWdQ3rG0ekuWscHraeIbnI8t+aZK7qhYqEqWKTUdijadunb9pnrgA==}
+    dev: true
+
+  /@vue/shared@3.4.38:
+    resolution: {integrity: sha512-q0xCiLkuWWQLzVrecPb0RMsNWyxICOjPrcrwxTUEHb1fsnvni4dcuyG7RT/Ie7VPTvnjzIaWzRMUBsrqNj/hhw==}
     dev: true
 
   /acorn-jsx@5.3.2(acorn@8.11.3):

--- a/src/index.ts
+++ b/src/index.ts
@@ -239,6 +239,7 @@ function getByPath<T extends SearchableObject, P extends PathEntry<T> & string>(
     if (
       typeof current !== 'object' ||
       current === null ||
+      (current as SafeObject)[pathPart] === undefined ||
       !hasOwnProperty.call(current, pathPart)
     ) {
       return undefined


### PR DESCRIPTION
Fixes #34

This is a backport of the change from the 2.x version. Thanks to @Tofandel for reporting the issue.

We simply just added a condition to the reduce code to actually touch the objects instead of only checking the path existence via the `hasOwnProperty` call.

This enables frameworks like Vue to properly track the reactivity on return values again.